### PR TITLE
Fix RTD with submodules

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,11 @@ build:
 sphinx:
    configuration: docs/conf.py
 
+# clone submodules
+submodules:
+  include: all
+  recursive: true
+
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:
 #    - pdf


### PR DESCRIPTION
Turns out they don't clone them by default https://docs.readthedocs.io/en/stable/config-file/v2.html#submodules