### PR TITLE
Fix imports & fix bug in `model_chooser`

### DIFF
--- a/fusilli/fusionmodels/tabularfusion/mcvae_model.py
+++ b/fusilli/fusionmodels/tabularfusion/mcvae_model.py
@@ -6,11 +6,7 @@ two types of tabular data.
 import torch.nn as nn
 from fusilli.fusionmodels.base_model import ParentFusionModel
 import torch
-# from fusilli.utils.mcvae.src.mcvae.models import Mcvae
-import fusilli.utils.mcvae as mcvae
-from mcvae.models import Mcvae
-from mcvae.models.utils import DEVICE
-# from fusilli.utils.mcvae.src.mcvae.models.utils import DEVICE
+from fusilli.utils.mcvae.src.mcvae.models import Mcvae
 import contextlib
 import pandas as pd
 import numpy as np

--- a/fusilli/utils/model_chooser.py
+++ b/fusilli/utils/model_chooser.py
@@ -71,9 +71,6 @@ fusion_model_dict = [
     {
         "name": "AttentionWeightedGNN",
         "path": "fusionmodels.tabularfusion.attention_weighted_GNN",
-    },
-    {
-
     }
 ]
 


### PR DESCRIPTION
So this hack will work for the submodule (have run `python -m sphinx -T -E -b html -d _build/doctrees -D language=en . html` locally).

Having submodules like this isn't standard practice, but this will work without other changes. You'll need to replace this with your current `main`. Also FYI with `readthedocs` you can build from branch I believe.

There was also a bug in `model_chooser.py` which I fixed after the import step.