### PR TITLE
Relax pinning versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,20 @@ classifiers = [
 ]
 keywords= ["multi-modal", "machine learning", "MRI", "data fusion", "multi-view", "graph neural network", "attention", "VAE"]
 dependencies = [
-    "lightning==2.1.0",
-    "matplotlib==3.5.3",
-    "numpy==1.25.1",
-    "pandas==2.0.3",
-    "scikit_learn==1.1.3",
-    "setuptools==68.2.2",
-    "torch==2.0.1",
-    "torch_geometric==2.3.0",
-    "torchmetrics==0.10.3",
-    "tqdm==4.64.1",
-    "wandb==0.15.3",
+    "lightning~=2.0",
+    "matplotlib~=3.0",
+    "numpy~=1.0",
+    "pandas~=2.0",
+    "scikit_learn~=1.0",
+    "setuptools~=68.0",
+    "torch~=2.0",
+    "torch_geometric~=2.0",
+    "torchmetrics~=0.0",
+    "tqdm~=4.0",
+    "wandb~=0.0",
 ]
 optional-dependencies = {docs = [
-    "protobuf==3.19.6",
+    "protobuf~=3.0",
     "sphinx",
     "sphinx-gallery",
     "sphinx-rtd-theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,17 +44,6 @@ optional-dependencies = {docs = [
     "sphinxcontrib-qthelp",
     "sphinxcontrib-serializinghtml",
     "renku-sphinx-theme",
-    "lightning==2.1.0",
-    "matplotlib==3.5.3",
-    "numpy==1.25.1",
-    "pandas==2.0.3",
-    "scikit_learn==1.1.3",
-    "setuptools==68.2.2",
-    "torch==2.0.1",
-    "torch_geometric==2.3.0",
-    "torchmetrics==0.10.3",
-    "tqdm==4.64.1",
-    "wandb==0.15.3",
 ]}
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
I couldn't build locally due to the `matplotlib` version. This syntax means, i.e. `matplotlib` will get all versions from `3.0` but `<= 4.0`.

Also, now we're using `pip install -e .` and `pip install -e .[docs]` there is no need to repeat dependencies in both sections.