### PR TITLE
Include submodules in action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - name: Set up Python
       uses: actions/setup-python@v3
       with:


### PR DESCRIPTION
This should fix having `mcvae` available when installing from PyPI