### PR TITLE
Refactor/traintestsplit: Adding train test split customisability to the data loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,8 @@ cython_debug/
 
 # tracks the version
 _version.py
+
+# rogue directories from example notebooks running in local space
+checkpoints/
+loss_figures/
+loss_logs/

--- a/fusilli/data.py
+++ b/fusilli/data.py
@@ -437,7 +437,6 @@ class TrainTestDataModule(pl.LightningDataModule):
             prediction_task,
             batch_size,
             test_size,
-            num_folds,  # not needed for train/test split
             multiclass_dimensions,
             subspace_method=None,
             image_downsample_size=None,
@@ -465,8 +464,6 @@ class TrainTestDataModule(pl.LightningDataModule):
             Batch size (default 8).
         test_size : float
             Fraction of data to use for testing (default 0.2).
-        num_folds : int
-            Total number of folds. Not needed for this class for train/test split but it's here to be consistent with KFoldDataModule.
         multiclass_dimensions : int
             Number of classes for multiclass prediction (default None).
         subspace_method : class
@@ -738,7 +735,6 @@ class KFoldDataModule(pl.LightningDataModule):
             prediction_task,
             batch_size,
             num_folds,
-            test_size,  # not needed for k-fold
             multiclass_dimensions,
             subspace_method=None,
             image_downsample_size=None,
@@ -1259,6 +1255,7 @@ class KFoldGraphDataModule:
             image_downsample_size=None,
             layer_mods=None,
             extra_log_string_dict=None,
+            own_kfold_indices=None,
     ):
         """
         Parameters
@@ -1279,6 +1276,10 @@ class KFoldGraphDataModule:
             (default None)
         extra_log_string_dict : dict
             Dictionary of extra strings to add to the log.
+        own_kfold_indices : list
+            List of indices to use for k-fold cross validation (default None). If None, the k-fold
+            indices are randomly selected. Structure is a list of tuples of (train_indices,
+            test_indices). Must be the same length as num_folds.
         """
         super().__init__()
         self.num_folds = num_folds  # total number of folds
@@ -1304,6 +1305,7 @@ class KFoldGraphDataModule:
         self.modality_type = self.fusion_model.modality_type
         self.graph_creation_method = graph_creation_method
         self.layer_mods = layer_mods
+        self.own_kfold_indices = own_kfold_indices
 
     def prepare_data(self):
         """
@@ -1322,21 +1324,28 @@ class KFoldGraphDataModule:
         Returns
         ------
         folds : list
-            List of tuples of (graph_data, train_idxs, test_idxs)
+            List of tuples of (train_dataset, test_dataset)
         """
-        # splits the dataset into k folds
-        kf = KFold(n_splits=self.num_folds, shuffle=True)
-        indices = list(range(len(self.dataset)))  # get the indices of the dataset
+        # get the indices of the dataset
+        indices = list(range(len(self.dataset)))
+
+        # split the dataset into k folds
+        if self.own_kfold_indices is None:
+            kf = KFold(n_splits=self.num_folds, shuffle=True)
+            split_kf = kf.split(indices)
+        else:
+            split_kf = self.own_kfold_indices
 
         folds = []
-        for train_indices, val_indices in kf.split(indices):
+        for train_indices, val_indices in split_kf:
             # split the dataset into train and test sets for each fold
             train_dataset = torch.utils.data.Subset(self.dataset, train_indices)
             test_dataset = torch.utils.data.Subset(self.dataset, val_indices)
-            folds.append(
-                (train_dataset, test_dataset)
-            )  # list of tuples of (train_dataset, test_dataset)
-        return folds
+
+            # append the train and test datasets to the folds list
+            folds.append((train_dataset, test_dataset))
+
+        return folds  # list of tuples of (train_dataset, test_dataset)
 
     def setup(self):
         """
@@ -1422,6 +1431,7 @@ def prepare_fusion_data(
         own_early_stopping_callback=None,
         num_workers=0,
         test_indices=None,
+        own_kfold_indices=None,
         **kwargs,
 ):
     """
@@ -1471,6 +1481,8 @@ def prepare_fusion_data(
         Number of workers for the dataloader (default 0).
     test_indices : list or None
         List of indices to use for testing (default None). If None, then random split is used.
+    own_kfold_indices : list or None
+        List of indices to use for k-fold cross validation (default None). If None, then random split is used.
     **kwargs : dict
         Extra keyword arguments. Usable for extra arguments for the subspace method MCVAE's early stopping callback: "mcvae_patience" and "mcvae_tolerance".
 
@@ -1547,29 +1559,43 @@ def prepare_fusion_data(
     else:
         # another other than graph fusion
         if kfold:
-            datamodule_func = KFoldDataModule
+            data_module = KFoldDataModule(
+                fusion_model,
+                sources=data_sources,
+                output_paths=output_paths,
+                prediction_task=prediction_task,
+                batch_size=batch_size,
+                num_folds=num_folds,
+                multiclass_dimensions=multiclass_dimensions,
+                subspace_method=fusion_model.subspace_method,
+                image_downsample_size=image_downsample_size,
+                layer_mods=layer_mods,
+                max_epochs=max_epochs,
+                extra_log_string_dict=extra_log_string_dict,
+                own_early_stopping_callback=own_early_stopping_callback,
+                num_workers=num_workers,
+                own_kfold_indices=own_kfold_indices,
+                kwargs=kwargs,
+            )
         else:
-            datamodule_func = TrainTestDataModule
-
-        data_module = datamodule_func(
-            fusion_model,
-            sources=data_sources,
-            output_paths=output_paths,
-            prediction_task=prediction_task,
-            batch_size=batch_size,
-            test_size=test_size,
-            num_folds=num_folds,
-            multiclass_dimensions=multiclass_dimensions,
-            subspace_method=fusion_model.subspace_method,
-            image_downsample_size=image_downsample_size,
-            layer_mods=layer_mods,
-            max_epochs=max_epochs,
-            extra_log_string_dict=extra_log_string_dict,
-            own_early_stopping_callback=own_early_stopping_callback,
-            num_workers=num_workers,
-            test_indices=test_indices,
-            kwargs=kwargs,
-        )
+            data_module = TrainTestDataModule(
+                fusion_model,
+                sources=data_sources,
+                output_paths=output_paths,
+                prediction_task=prediction_task,
+                batch_size=batch_size,
+                test_size=test_size,
+                multiclass_dimensions=multiclass_dimensions,
+                subspace_method=fusion_model.subspace_method,
+                image_downsample_size=image_downsample_size,
+                layer_mods=layer_mods,
+                max_epochs=max_epochs,
+                extra_log_string_dict=extra_log_string_dict,
+                own_early_stopping_callback=own_early_stopping_callback,
+                num_workers=num_workers,
+                test_indices=test_indices,
+                kwargs=kwargs,
+            )
         data_module.prepare_data()
         data_module.setup(checkpoint_path=checkpoint_path)
 

--- a/fusilli/data.py
+++ b/fusilli/data.py
@@ -1158,7 +1158,7 @@ class TrainTestGraphDataModule:
         None
         """
         # get random train and test idxs
-        if self.own_test_indices is not None:
+        if self.own_test_indices is None:
             [train_dataset, test_dataset] = torch.utils.data.random_split(
                 self.dataset, [1 - self.test_size, self.test_size]
             )

--- a/fusilli/data.py
+++ b/fusilli/data.py
@@ -571,6 +571,7 @@ class TrainTestDataModule(pl.LightningDataModule):
             self.test_dataset = torch.utils.data.Subset(
                 self.dataset, self.test_indices
             )
+
             self.train_dataset = torch.utils.data.Subset(
                 self.dataset, list(set(range(len(self.dataset))) - set(self.test_indices))
             )

--- a/tests/test_data/test_KFoldDataModule.py
+++ b/tests/test_data/test_KFoldDataModule.py
@@ -32,7 +32,6 @@ def create_kfold_data_module(create_test_files):
         multiclass_dimensions=params["multiclass_dims"],
         num_folds=params["num_k"],
         batch_size=batch_size,
-        test_size=0.2
     )
 
     return data_module
@@ -72,7 +71,6 @@ def test_kfold_split_own_indices(create_test_files_more_features):
     tabular2_csv = create_test_files_more_features["tabular2_csv"]
     image_torch_file_2d = create_test_files_more_features["image_torch_file_2d"]
 
-    test_size = 0.2
     prediction_task = "binary"
     multiclass_dimensions = None
 
@@ -91,7 +89,6 @@ def test_kfold_split_own_indices(create_test_files_more_features):
         prediction_task=prediction_task,
         multiclass_dimensions=multiclass_dimensions,
         num_folds=5,
-        test_size=test_size,
         own_kfold_indices=own_folds,
         batch_size=9,
     )

--- a/tests/test_data/test_TrainTestDataModule.py
+++ b/tests/test_data/test_TrainTestDataModule.py
@@ -255,6 +255,49 @@ def test_setup_calls_subspace_method(create_test_files):
         )
 
 
+# Testing that the test indices are correctly input and used instead of a random split
+def test_owntestindices(create_test_files_more_features):
+    tabular1_csv = create_test_files_more_features["tabular1_csv"]
+    tabular2_csv = create_test_files_more_features["tabular2_csv"]
+    image_torch_file_2d = create_test_files_more_features["image_torch_file_2d"]
+
+    test_size = 0.2
+    prediction_task = "binary"
+    multiclass_dimensions = None
+
+    sources = [tabular1_csv, tabular2_csv, image_torch_file_2d]
+    batch_size = 23
+
+    example_fusion_model = Mock()
+    example_fusion_model.modality_type = "tabular_image"
+
+    # make test indices people 30 to 36
+    test_indices = list(range(25, 36))
+
+    datamodule = TrainTestDataModule(fusion_model=example_fusion_model,
+                                     sources=sources,
+                                     output_paths=None,
+                                     prediction_task=prediction_task,
+                                     batch_size=batch_size,
+                                     test_size=test_size,
+                                     multiclass_dimensions=multiclass_dimensions,
+                                     num_folds=None,
+                                     test_indices=test_indices)
+    datamodule.prepare_data()
+    datamodule.setup()
+
+    # check that the test indices are correctly input
+    assert datamodule.test_indices == test_indices
+    # look at the test dataset
+    test_dataset = datamodule.test_dataset
+    # check that the test dataset has the correct number of people
+    assert len(test_dataset) == len(test_indices)
+    # check train dataset
+    train_dataset = datamodule.train_dataset
+    # check that the train dataset has the correct number of people
+    assert len(train_dataset) == 25
+
+
 # Run pytest
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_data/test_TrainTestDataModule.py
+++ b/tests/test_data/test_TrainTestDataModule.py
@@ -271,7 +271,7 @@ def test_owntestindices(create_test_files_more_features):
     example_fusion_model = Mock()
     example_fusion_model.modality_type = "tabular_image"
 
-    # make test indices people 30 to 36
+    # make test indices people 25 to 36
     test_indices = list(range(25, 36))
 
     datamodule = TrainTestDataModule(fusion_model=example_fusion_model,

--- a/tests/test_data/test_TrainTestDataModule.py
+++ b/tests/test_data/test_TrainTestDataModule.py
@@ -153,8 +153,7 @@ def test_train_dataloader(create_test_files):
                                      prediction_task=prediction_task,
                                      batch_size=batch_size,
                                      test_size=test_size,
-                                     multiclass_dimensions=None,
-                                     num_folds=None)
+                                     multiclass_dimensions=None, )
 
     datamodule.prepare_data()
     datamodule.setup()
@@ -190,8 +189,7 @@ def test_val_dataloader(create_test_files):
                                      prediction_task=prediction_task,
                                      batch_size=batch_size,
                                      test_size=test_size,
-                                     multiclass_dimensions=multiclass_dimensions,
-                                     num_folds=None)
+                                     multiclass_dimensions=multiclass_dimensions, )
     datamodule.prepare_data()
     datamodule.setup()
 
@@ -244,7 +242,6 @@ def test_setup_calls_subspace_method(create_test_files):
                                          batch_size=batch_size,
                                          test_size=test_size,
                                          multiclass_dimensions=multiclass_dimensions,
-                                         num_folds=None,
                                          subspace_method=mock_subspace_method)
         datamodule.prepare_data()
         datamodule.setup()
@@ -281,7 +278,6 @@ def test_owntestindices(create_test_files_more_features):
                                      batch_size=batch_size,
                                      test_size=test_size,
                                      multiclass_dimensions=multiclass_dimensions,
-                                     num_folds=None,
                                      test_indices=test_indices)
     datamodule.prepare_data()
     datamodule.setup()

--- a/tests/test_data/test_TrainTestGraphDataModule.py
+++ b/tests/test_data/test_TrainTestGraphDataModule.py
@@ -1,6 +1,6 @@
 import pytest
 from fusilli.data import TrainTestGraphDataModule
-from .test_TrainTestDataModule import create_test_files
+from .test_TrainTestDataModule import create_test_files, create_test_files_more_features
 from pytest import approx
 from pytest_mock import mocker
 
@@ -27,8 +27,6 @@ def create_graph_data_module(create_test_files):
 
     sources = [tabular1_csv, tabular2_csv, image_torch_file_2d]
     batch_size = 23
-
-    # modality_type = "tabular_tabular"
 
     class example_fusion_model:
         modality_type = "tabular_tabular"
@@ -96,6 +94,46 @@ def test_get_lightning_module(create_graph_data_module):
 
     # Add assertions to check the expected behavior of the lightning module
     assert lightning_module is not None
+
+
+# Testing the TrainTestGraphDataModule class for the case where the user specifies their own test indices
+def test_owntestindices(create_test_files_more_features):
+    params = {
+        "test_size": 0.3,
+        "pred_type": "binary",
+        "multiclass_dims": None,
+    }
+
+    tabular1_csv = create_test_files_more_features["tabular1_csv"]
+    tabular2_csv = create_test_files_more_features["tabular2_csv"]
+    image_torch_file_2d = create_test_files_more_features["image_torch_file_2d"]
+
+    sources = [tabular1_csv, tabular2_csv, image_torch_file_2d]
+    batch_size = 23
+
+    # make test indices people 25 to 36
+    test_indices = list(range(25, 36))
+
+    class example_fusion_model:
+        modality_type = "tabular_tabular"
+
+        def __init__(self):
+            pass
+
+    data_module = TrainTestGraphDataModule(
+        fusion_model=example_fusion_model,
+        sources=sources,
+        graph_creation_method=MockGraphMakerModule,
+        test_size=params["test_size"],
+        own_test_indices=test_indices,
+    )
+
+    data_module.prepare_data()
+    data_module.setup()
+    lightning_module = data_module.get_lightning_module()
+
+    # check that the test indices are the same as the ones we specified
+    assert data_module.test_idxs == test_indices
 
 
 if __name__ == "__main__":

--- a/tests/test_models/test_subspace_and_graph_methods.py
+++ b/tests/test_models/test_subspace_and_graph_methods.py
@@ -58,7 +58,6 @@ def sample_datamodule(create_test_files):
                              prediction_task="binary",
                              batch_size=8,
                              test_size=0.3,
-                             num_folds=None,
                              multiclass_dimensions=None,
                              )
 
@@ -96,7 +95,6 @@ def sample_tabimg_datamodule(create_test_files):
                              prediction_task="binary",
                              batch_size=8,
                              test_size=0.3,
-                             num_folds=None,
                              multiclass_dimensions=None,
                              )
 

--- a/tests/test_modifications/test_subspace_modifications.py
+++ b/tests/test_modifications/test_subspace_modifications.py
@@ -731,8 +731,7 @@ def model_instance_denoising_autoencoder_subspace_method_2D(create_test_files):
                              prediction_task="binary",
                              batch_size=batch_size,
                              test_size=0.2,
-                             multiclass_dimensions=None,
-                             num_folds=None)
+                             multiclass_dimensions=None, )
     dm.prepare_data()
     dm.setup()
 
@@ -757,8 +756,7 @@ def model_instance_denoising_autoencoder_subspace_method_3D(create_test_files):
                              prediction_task="binary",
                              batch_size=batch_size,
                              test_size=0.2,
-                             multiclass_dimensions=None,
-                             num_folds=None)
+                             multiclass_dimensions=None, )
     dm.prepare_data()
     dm.setup()
 
@@ -783,7 +781,7 @@ def model_instance_concat_img_latent_tab_subspace_method_2D(create_test_files):
                              prediction_task="binary",
                              batch_size=batch_size,
                              test_size=0.2,
-                             multiclass_dimensions=None, num_folds=None)
+                             multiclass_dimensions=None, )
     dm.prepare_data()
     dm.setup()
 
@@ -808,7 +806,7 @@ def model_instance_concat_img_latent_tab_subspace_method_3D(create_test_files):
                                      prediction_task="binary",
                                      batch_size=batch_size,
                                      test_size=0.2,
-                                     multiclass_dimensions=None, num_folds=None)
+                                     multiclass_dimensions=None, )
     datamodule.prepare_data()
     datamodule.setup()
 


### PR DESCRIPTION
Allowing users to specify their own train and test indices for better experiment customisability and experiment reproducibility. Also users can specify their own kfold indices for cross validation.